### PR TITLE
realtime ingest of quicker nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ To run locally perform the following set up steps
   - CIRCLE_CI_AUTH_TOKEN
   - NEWRELIC_API_KEY
   - NEWRELIC_APP_NAME
+  - LANTERN_URL
 3. bundle install
 4. dashing start

--- a/jobs/lantern_data_hist_ingest.rb
+++ b/jobs/lantern_data_hist_ingest.rb
@@ -2,14 +2,14 @@ require 'httparty'
 require 'json'
 
 SCHEDULER.every '1m', :first_in => 0, :allow_overlapping => false, :timeout => '59s' do |job|
-    url = 'http://lantern.ft.com/status'
-    
+    url = ENV['LANTERN_URL'] + '/status'
+
     response =  HTTParty.get(url, :headers => { "Accept" => "application/json" } )
     json_response = JSON.parse(response.body)
     json_response = json_response['historical']
-    
+
     date = DateTime.strptime(json_response['latestIndex'], "%Y-%m-%d")
     formattedDate = date.strftime("%d-%m-%Y")
-    
+
     send_event('LANTERN_DATA_HIST_INGEST', { metric: formattedDate, type: 'historical' })
 end

--- a/jobs/lantern_data_real_ingest.rb
+++ b/jobs/lantern_data_real_ingest.rb
@@ -2,15 +2,21 @@ require 'httparty'
 require 'json'
 
 SCHEDULER.every '1m', :first_in => 0, :allow_overlapping => false, :timeout => '59s' do |job|
-    url = 'http://lantern.ft.com/status'
-    
+    url = ENV['LANTERN_URL'] + '/status'
+
     response =  HTTParty.get(url, :headers => { "Accept" => "application/json" } )
     json_response = JSON.parse(response.body)
     json_response = json_response['realtime']
-    
-    date = DateTime.strptime(json_response['latestIndex'], "%Y-%m-%d-%H")
+
+    date = DateTime.iso8601(json_response['docDate'])
     formattedDate = date.strftime("%d-%m-%Y")
-    hour = date.strftime("%R")
-    
-    send_event('LANTERN_DATA_REAL_INGEST', { metric: formattedDate, hour: hour, type: 'realtime'})
+    hour = date.strftime("%H:%M")
+    status = json_response['status'];
+
+    send_event('LANTERN_DATA_REAL_INGEST', {
+      status: status,
+      metric: formattedDate,
+      hour: hour,
+      type: 'realtime'
+    })
 end

--- a/widgets/lantern_data_ingest/lantern_data_ingest.coffee
+++ b/widgets/lantern_data_ingest/lantern_data_ingest.coffee
@@ -5,16 +5,15 @@ class Dashing.LanternDataIngest extends Dashing.Widget
     metric = data.metric.split("-")
     inputDate = new Date(metric[2], metric[1] - 1, metric[0]);
     todaysDate = new Date();
-            
+
     if inputDate.setHours(0,0,0,0) == todaysDate.setHours(0,0,0,0)
       $(@get('node')).removeClass 'ingest-error'
     else
-      $(@get('node')).addClass 'ingest-error'    
-        
+      $(@get('node')).addClass 'ingest-error'
+
     if data.type == 'realtime'
-      hour = new Date().getHours() + ":00";
-      if hour == data.hour
+      if data.status == 'ok'
         $(@get('node')).removeClass 'ingest-error'
       else
         $(@get('node')).addClass 'ingest-error'
-        
+


### PR DESCRIPTION
now we use the `event_timestamp` field of the latest document to enter the elasticsearch cluster
